### PR TITLE
FEAT : 커뮤니티 페이지 인기 게시글 출력 추가

### DIFF
--- a/src/main/java/com/pulbatte/pulbatte/post/controller/PostController.java
+++ b/src/main/java/com/pulbatte/pulbatte/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.pulbatte.pulbatte.post.controller;
 import com.pulbatte.pulbatte.global.MsgResponseDto;
 import com.pulbatte.pulbatte.global.exception.SuccessCode;
 import com.pulbatte.pulbatte.global.security.UserDetailsImpl;
+import com.pulbatte.pulbatte.post.dto.PostFavResponseDto;
 import com.pulbatte.pulbatte.post.dto.PostRequestDto;
 import com.pulbatte.pulbatte.post.dto.PostResponseDto;
 import com.pulbatte.pulbatte.post.service.PostService;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,7 +26,7 @@ public class PostController {
 
     private final PostService postService;
 
-    //게시글 생성
+    // 게시글 생성
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public MsgResponseDto createPost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -33,11 +35,17 @@ public class PostController {
         postService.createPost(request, userDetails.getUser(), multipartFile);
         return new MsgResponseDto(SuccessCode.CREATE_BOARD);
     }
-    //게시글 전체 조회
+    // 게시글 전체 조회
     @GetMapping
     public Page<PostResponseDto> getListPosts(
             @PageableDefault(size = 20) Pageable pageable) {
+
         return postService.getListPosts(pageable);
+    }
+    // 인기 게시글 조회
+    @GetMapping("/popular")
+    public List<PostFavResponseDto> getPopularListPosts(){
+        return postService.getPopularListPosts();
     }
     // 게시글 상세 조회
     @GetMapping("/{postId}")
@@ -46,7 +54,7 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return postService.getPost(postId, userDetails.getUser());
     }
-    //게시글 수정
+    // 게시글 수정
     @PutMapping("/{postId}")
     public PostResponseDto updatePost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -63,7 +71,7 @@ public class PostController {
         postService.deletePost(postId, userDetails.getUser());
         return new MsgResponseDto(SuccessCode.DELETE_BOARD);
     }
-    //게시글 좋아요, 좋아요 취소
+    // 게시글 좋아요, 좋아요 취소
     @PostMapping("/{postId}/postLike")
     public MsgResponseDto saveBoardLike(
             @PathVariable Long postId,

--- a/src/main/java/com/pulbatte/pulbatte/post/dto/PostFavResponseDto.java
+++ b/src/main/java/com/pulbatte/pulbatte/post/dto/PostFavResponseDto.java
@@ -1,0 +1,21 @@
+package com.pulbatte.pulbatte.post.dto;
+
+import com.pulbatte.pulbatte.post.entity.Post;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PostFavResponseDto {
+    private Long id;
+    private String title;
+    private String image;
+
+    public PostFavResponseDto(Post post){
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.image = post.getImage();
+
+    }
+}

--- a/src/main/java/com/pulbatte/pulbatte/post/entity/Post.java
+++ b/src/main/java/com/pulbatte/pulbatte/post/entity/Post.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity(name = "post")
@@ -27,8 +28,13 @@ public class Post extends TimeStamped {
     private int category;
     @Column(nullable = false)
     private String image;
+    @Column
+    private LocalDateTime favLikeTime;
     @OneToMany(mappedBy = "post",cascade = CascadeType.REMOVE)
     private List<Comment> commentList;
+    @OneToMany(mappedBy = "post",cascade = CascadeType.REMOVE)
+    private List<PostLike> postLike;
+
 
     public Post(PostRequestDto postRequestDto , User user, String image){
         this.title = postRequestDto.getTitle();
@@ -45,6 +51,9 @@ public class Post extends TimeStamped {
     }
     public void update(String image){
         this.image = image;
+    }
+    public void updateFaveLikeTime(LocalDateTime favLikeTime){
+        this.favLikeTime = favLikeTime;
     }
 
 }

--- a/src/main/java/com/pulbatte/pulbatte/post/entity/PostLike.java
+++ b/src/main/java/com/pulbatte/pulbatte/post/entity/PostLike.java
@@ -3,8 +3,10 @@ package com.pulbatte.pulbatte.post.entity;
 import com.pulbatte.pulbatte.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.bytebuddy.asm.Advice;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 
 @Entity(name = "PostLike")
 @Getter
@@ -13,14 +15,14 @@ public class PostLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @ManyToOne
     @JoinColumn(name = "User_Id", nullable = false)                   // category(n) <-> User(1) 단방향 관계
     private User user;                                                // 좋아요 유저 Id
-
     @ManyToOne
     @JoinColumn(name = "Post_Id", nullable = false)                  // category(n) <-> Board(1) 단방향 관계
     private Post post;                                              // 좋아요 게시글 Id
+
+
 
     public PostLike(Post post, User user) {
         this.post = post;   // 게시글 정보

--- a/src/main/java/com/pulbatte/pulbatte/post/repository/LikeRepository.java
+++ b/src/main/java/com/pulbatte/pulbatte/post/repository/LikeRepository.java
@@ -9,10 +9,9 @@ import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByPostIdAndUserId(Long postId , Long userId);
-
     void deleteByPostIdAndUserId(Long postId, Long userId);
-
     //nativeQuery 를 사용하여 좋아요 개수 count
     @Query(value = "select count(1) from post_like inner join post on post_like.post_id = post.id where post_like.post_id = :postId", nativeQuery = true)
     Long likeCnt(@PathVariable("id") Long postId);
+    Optional<PostLike> findByPostId(Long postId);
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/56-> dev

### 변경 사항
- 게시글 출력 페이지에서 인기 게시글 출력 기능 추가
- 좋아요 개수에 따라 인기 게시글이 된 시간 순으로 정렬

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
인기 게시글이 되는 좋아요의 개수의 기준만 정해서 수정하면 됩니다.