### PR TITLE
식물 일지 다이어리 작성 시 작성 날짜 임의로 받아서 만들도록 수정

### DIFF
--- a/src/main/java/com/pulbatte/pulbatte/plantJournal/dto/PlantJournalDiaryRequestDto.java
+++ b/src/main/java/com/pulbatte/pulbatte/plantJournal/dto/PlantJournalDiaryRequestDto.java
@@ -6,5 +6,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PlantJournalDiaryRequestDto {
+    private String createdAt;
     private String content;
 }

--- a/src/main/java/com/pulbatte/pulbatte/plantJournal/entity/PlantJournalDiary.java
+++ b/src/main/java/com/pulbatte/pulbatte/plantJournal/entity/PlantJournalDiary.java
@@ -31,10 +31,14 @@ public class PlantJournalDiary extends TimeStamped {
 
 
 
-    public PlantJournalDiary(PlantJournalDiaryRequestDto plantJournalDiaryRequestDto, User user, PlantJournal plantJournal){
+    public PlantJournalDiary(
+            PlantJournalDiaryRequestDto plantJournalDiaryRequestDto, User user,
+            PlantJournal plantJournal, LocalDateTime createdAt
+    ){
         this.content = plantJournalDiaryRequestDto.getContent();
         this.user = user;
         this.plantJournal = plantJournal;
+        this.createdAt = createdAt;
     }
 
     public void update(String content){

--- a/src/main/java/com/pulbatte/pulbatte/plantJournal/service/PlantJournalDiaryService.java
+++ b/src/main/java/com/pulbatte/pulbatte/plantJournal/service/PlantJournalDiaryService.java
@@ -14,9 +14,12 @@ import com.pulbatte.pulbatte.plantJournal.repository.PlantJournalRepository;
 import com.pulbatte.pulbatte.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +36,11 @@ public class PlantJournalDiaryService {
         PlantJournal plantJournal = plantJournalRepository.findById(plantJournalId).orElseThrow(
                 () -> new CustomException(ErrorCode.NO_PLANT_JOURNAL_FOUND)
         );
-        plantJournalDiaryRepository.save(new PlantJournalDiary(plantJournalDiaryRequestDto, user, plantJournal));
+        String[] now = String.valueOf(LocalDateTime.now()).split("T");
+        String date = plantJournalDiaryRequestDto.getCreatedAt() + " " + now[1].substring(0,now[1].length()-3);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+        LocalDateTime createdAt = LocalDateTime.parse(date, formatter);
+        plantJournalDiaryRepository.save(new PlantJournalDiary(plantJournalDiaryRequestDto, user, plantJournal,createdAt));
     }
 
     // 식물 일지 다이어리 상세 조회


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature141-> dev

### 변경 사항
- 기존 LocalDateTiem.now로 사용하던 작성 시간을 임의로 작성 시간을 받아와서 만들도록 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.